### PR TITLE
markdown 2.1 compatibility

### DIFF
--- a/mdx_asciimathml.py
+++ b/mdx_asciimathml.py
@@ -36,7 +36,12 @@ class ASCIIMathMLPattern(markdown.inlinepatterns.Pattern):
         return re.compile(r'^(.*)\$\$([^\$]*)\$\$(.*)$', re.M) # $$ a $$
 
     def handleMatch(self, m):
-        math = asciimathml.parse(m.group(2).strip(), markdown.etree.Element, markdown.AtomicString)
+        if markdown.version_info < (2, 1, 0):
+            math = asciimathml.parse(m.group(2).strip(), markdown.etree.Element,
+                       markdown.AtomicString)
+        else:
+            math = asciimathml.parse(m.group(2).strip(),
+                       markdown.util.etree.Element, markdown.util.AtomicString)
         math.set('xmlns', 'http://www.w3.org/1998/Math/MathML')
         return math
 


### PR DESCRIPTION
(though I have 4 failures within test.py with Markdown==2.0.3 and the new version)
