### PR TITLE
Support quoted strings

### DIFF
--- a/asciimathml.py
+++ b/asciimathml.py
@@ -37,6 +37,7 @@ def El(tag, text=None, *children, **attrib):
     return element
 
 number_re = re.compile('-?(\d+\.(\d+)?|\.?\d+)')
+quoted_string_re = re.compile(r'"([^"]*)"')
 
 def strip_parens(n):
     if n.tag == 'mrow':
@@ -326,6 +327,11 @@ def parse_m(s, required=False):
 
     if s == '':
         return '', El('mi', u'\u25a1') if required else None
+
+    m = quoted_string_re.match(s)
+    if m:
+        text = m.group(1)
+        return s[m.end():], El('mrow', El('mtext', text))
 
     m = number_re.match(s)
 

--- a/test/test.py
+++ b/test/test.py
@@ -68,6 +68,13 @@ class ParseTestCase(unittest.TestCase):
             El('math', El('mstyle',
                 El('mrow', El('mtext', text='undefined')))))
 
+    def testQuotedText(self):
+        self.assertTreeEquals(parse('"time" = "money"'),
+            El('math', El('mstyle',
+                El('mrow', El('mtext', text='time')),
+                El('mo', text='='),
+                El('mrow', El('mtext', text='money')))))
+
     def testIncompleteFrac(self):
         self.assertTreeEquals(parse('alpha /'),
             El('math', El('mstyle',


### PR DESCRIPTION
The last ASCIIMath version supports using quotes to delimit `text` elements, like so:

Input:

```
"time" = "money"
```

Result:

``` html
<math xmlns="http://www.w3.org/1998/Math/MathML">
  <mstyle displaystyle="true">
    <mrow>
      <mtext>time</mtext>
    </mrow>
    <mo>=</mo>
    <mrow>
      <mtext>money</mtext>
    </mrow>
  </mstyle>
</math>
```

This commit brings the behaviour to the python implementation.
